### PR TITLE
Update master to 3.0.5.8

### DIFF
--- a/MidsReborn/Forms/frmMain.cs
+++ b/MidsReborn/Forms/frmMain.cs
@@ -1353,7 +1353,11 @@ namespace Mids_Reborn.Forms
                 pw.Power.FullName.StartsWith("Inherent.Inherent.White_Dwarf") |
                 pw.Power.FullName.StartsWith("Inherent.Inherent.Bright_Nova"));
 
-            if (dp.Level != -2) DoResize();
+            if (dp.Level != -2)
+            {
+                pnlGFX.Update();
+                pnlGFX.Refresh();
+            }
 
             return true;
         }

--- a/MidsReborn/Forms/frmMain.cs
+++ b/MidsReborn/Forms/frmMain.cs
@@ -1340,6 +1340,21 @@ namespace Mids_Reborn.Forms
             UpdateColors();
             FloatUpdate(true);
 
+            // Force rendering the bottom part of the main build UI if it any of the selected powers match these conditions:
+            // - Any accolade
+            // - Any incarnate power
+            // - Any PB/WS shapeshifting special power (dwarves and novae)
+            var dp = new PowerEntry { Level = -2 };
+            var p = MidsContext.Character.CurrentBuild.Powers.DefaultIfEmpty(dp).FirstOrDefault(pw =>
+                pw.Power.FullName.StartsWith("Temporary_Powers.Accolades.") |
+                pw.Power.FullName.StartsWith("Incarnate.") |
+                pw.Power.FullName.StartsWith("Inherent.Inherent.Black_Dwarf") |
+                pw.Power.FullName.StartsWith("Inherent.Inherent.Dark_Nova") |
+                pw.Power.FullName.StartsWith("Inherent.Inherent.White_Dwarf") |
+                pw.Power.FullName.StartsWith("Inherent.Inherent.Bright_Nova"));
+
+            if (dp.Level != -2) DoResize();
+
             return true;
         }
 

--- a/MidsReborn/MidsReborn.csproj
+++ b/MidsReborn/MidsReborn.csproj
@@ -2646,7 +2646,7 @@
       <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="RestSharp">
-      <Version>106.11.7</Version>
+      <Version>106.12.0</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.Grid.Windows">
       <Version>18.4.0.31</Version>

--- a/mrbBase/Base/Data_Classes/Character.cs
+++ b/mrbBase/Base/Data_Classes/Character.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
+using FastDeepCloner;
 using mrbBase.Base.Display;
 using mrbBase.Base.Master_Classes;
 
@@ -1379,6 +1379,19 @@ namespace mrbBase.Base.Data_Classes
             var poolIndex = new int[4];
             for (var i = 3; i <= 6; ++i)
             {
+                // This can actually happen.
+                // See: https://forums.homecomingservers.com/topic/19963-mids-reborn-hero-designer/?do=findComment&comment=382180
+                if (Powersets[i] == null)
+                {
+                    if (i == 3)
+                    {
+                        Powersets[i] = DatabaseAPI.GetPowersetByIndex(DatabaseAPI.GetPowersetIndexesByGroupName("Pool")[0]);
+                    }
+                    else
+                    {
+                        Powersets[i] = Powersets[i - 1].Clone();
+                    }
+                }
                 var ps = Powersets[i];
                 poolIndex[i - 3] = ps?.nID ?? -1;
                 poolOrder[i - 3] = ps != null ? GetEarliestPowerIndex(Powersets[i].nID) : -1;

--- a/mrbBase/Base/Master_Classes/MidsContext.cs
+++ b/mrbBase/Base/Master_Classes/MidsContext.cs
@@ -9,8 +9,8 @@ namespace mrbBase.Base.Master_Classes
         private const int AppMajorVersion = 3;
         private const int AppMinorVersion = 0;
         private const int AppBuildVersion = 5;
-        private const int AppRevisionVersion = 7;
-        public const string AppAssemblyVersion = "3.0.5.7";
+        private const int AppRevisionVersion = 8;
+        public const string AppAssemblyVersion = "3.0.5.8";
         public const string AppVersionStatus = "";
 
         public const string Title = "Mids' Reborn";

--- a/mrbBase/DatabaseAPI.cs
+++ b/mrbBase/DatabaseAPI.cs
@@ -1364,7 +1364,7 @@ namespace mrbBase
                 writer.Write(Database.Issue);
                 writer.Write("BEGIN:ARCHETYPES");
                 Database.ArchetypeVersion.StoreTo(writer);
-                Console.WriteLine(Database.ArchetypeVersion);
+                //Console.WriteLine(Database.ArchetypeVersion);
                 writer.Write(Database.Classes.Length - 1);
                 for (var index = 0; index <= Database.Classes.Length - 1; ++index)
                 {

--- a/mrbBase/Enums.cs
+++ b/mrbBase/Enums.cs
@@ -1311,6 +1311,37 @@ namespace mrbBase
             Influence = 6
         }
 
+        public enum eColorSetting
+        {
+            ColorBackgroundHero = 0,
+            ColorBackgroundVillain = 1,
+            ColorText = 2,
+            ColorInvention = 3,
+            ColorInventionInv = 4,
+            ColorFaded = 5,
+            ColorEnhancement = 6,
+            ColorWarning = 7,
+            ColorPlName = 8,
+            ColorPlSpecial = 9,
+            ColorPowerAvailable = 10,
+            ColorPowerDisabled = 11,
+            ColorPowerTakenHero = 12,
+            ColorPowerTakenDarkHero = 13,
+            ColorPowerHighlightHero = 14,
+            ColorPowerTakenVillain = 15,
+            ColorPowerTakenDarkVillain = 16,
+            ColorPowerHighlightVillain = 17,
+            ColorDamageBarBase = 18,
+            ColorDamageBarEnh = 19
+        }
+
+        public enum eFontSizeSetting
+        {
+            PairedBase = 0,
+            PowersSelectBase = 1,
+            PowersBase = 2
+        }
+
         public static bool MezDurationEnhancable(eMez mezEnum)
         {
             return mezEnum == eMez.Confused || mezEnum == eMez.Held || mezEnum == eMez.Immobilized ||

--- a/mrbBase/Files.cs
+++ b/mrbBase/Files.cs
@@ -51,7 +51,7 @@ namespace mrbBase
 
         public static string FNamePowersRepl => Path.Combine(FPathAppData, MxdbPowersReplTable);
 
-        private static string FPathAppData => MidsContext.Config.DataPath;
+        private static string FPathAppData => MidsContext.Config != null ? MidsContext.Config.DataPath : FDefaultPath;
 
         internal static string SearchUp(string folder, string fn)
         {
@@ -173,7 +173,8 @@ namespace mrbBase
                 }
                 case false when !File.Exists(FNameJsonConfig):
                 {
-                    MessageBox.Show(@"Config file doesn't exist, generating a new one.");
+                    MessageBox.Show(@"Config file doesn't exist, generating a new one.", "Missing config file", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    File.WriteAllText(FNameJsonConfig, "");
                     return FNameJsonConfig;
                 }
                 case true when File.Exists(FNameConfig):

--- a/mrbBase/MidsCharacterFileFormat.cs
+++ b/mrbBase/MidsCharacterFileFormat.cs
@@ -347,10 +347,15 @@ namespace mrbBase
                 for (var index = 0; index < powerSetCount + 1; ++index)
                 {
                     var iName = r.ReadString();
-                    if (iName == "Pool.Leadership_beta")
+                    iName = iName switch
                     {
-                        iName = "Pool.Leadership";
-                    }
+                        "Pool.Leadership_beta" => "Pool.Leadership",
+
+                        // Partial support for builds made with MHD 1.x
+                        "Blaster_Support.Atomic_Manipulation" => "Blaster_Support.Radiation_Manipulation",
+                        "Pool.Fitness" => "Pool.Invisibility",
+                        _ => iName
+                    };
 
                     names.Add(iName);
                 }

--- a/mrbBase/Zlib.cs
+++ b/mrbBase/Zlib.cs
@@ -65,7 +65,7 @@ namespace mrbBase
 
         public static byte[] UncompressChunk(ref byte[] iBytes, int outSize)
         {
-            Console.WriteLine(Environment.CurrentDirectory);
+            //Console.WriteLine(Environment.CurrentDirectory);
             // zlib doesn't seem to work in 64bit, try this, and fallback to trying zlib if failed
             //if (is64BitProcess && File.Exists(ExternalCompressionName))
             //{

--- a/mrbControls/clsDrawX.cs
+++ b/mrbControls/clsDrawX.cs
@@ -686,10 +686,10 @@ namespace mrbControls
                 SolidBrush solidBrush;
                 //if (!System.Diagnostics.Debugger.IsAttached || !this.IsInDesignMode() || !System.Diagnostics.Process.GetCurrentProcess().ProcessName.ToLowerInvariant().Contains("devenv"))
                 var inDesigner = Process.GetCurrentProcess().ProcessName.ToLowerInvariant().Contains("devenv");
-                for (var i = 0; i <= iSlot.Slots.Length - 1; i++)
+                for (var i = 0; i < iSlot.Slots.Length; i++)
                 {
                     var slot = iSlot.Slots[i];
-                    // Enhancment spacing and position?
+                    // Enhancement spacing and position?
                     rectangleF.X = slotLocation.X + (szSlot.Width + 2) * i;
                     rectangleF.Y = slotLocation.Y;
                     //
@@ -964,8 +964,9 @@ namespace mrbControls
 
             var brush = new SolidBrush(outlineColor);
             var layoutRectangle = bounds;
-            var layoutRectangle2 = new RectangleF(layoutRectangle.X, layoutRectangle.Y, layoutRectangle.Width,
-                bFont.GetHeight(g));
+            var layoutRectangle2 = new RectangleF(layoutRectangle.X, layoutRectangle.Y, layoutRectangle.Width, bFont.GetHeight(g));
+            Debug.WriteLine($"Font size: {bFont.Size}, {bFont.GetHeight(g)}");
+            Debug.WriteLine($"DrawOutlineText() layoutRectangle2: {{X: {layoutRectangle2.X}, Y: {layoutRectangle2.Y}, Width: {layoutRectangle2.Width}, Height: {layoutRectangle2.Height}}}");
             layoutRectangle2.X -= outlineSpace;
             if (!smallMode)
                 g.DrawString(iStr, bFont, brush, layoutRectangle2, stringFormat);

--- a/mrbControls/clsDrawX.cs
+++ b/mrbControls/clsDrawX.cs
@@ -965,8 +965,6 @@ namespace mrbControls
             var brush = new SolidBrush(outlineColor);
             var layoutRectangle = bounds;
             var layoutRectangle2 = new RectangleF(layoutRectangle.X, layoutRectangle.Y, layoutRectangle.Width, bFont.GetHeight(g));
-            Debug.WriteLine($"Font size: {bFont.Size}, {bFont.GetHeight(g)}");
-            Debug.WriteLine($"DrawOutlineText() layoutRectangle2: {{X: {layoutRectangle2.X}, Y: {layoutRectangle2.Y}, Width: {layoutRectangle2.Width}, Height: {layoutRectangle2.Height}}}");
             layoutRectangle2.X -= outlineSpace;
             if (!smallMode)
                 g.DrawString(iStr, bFont, brush, layoutRectangle2, stringFormat);


### PR DESCRIPTION
App:
- Fix mids data path (AppPath\Data) detection, may lead to a crash if the config data is unreachable
- Fix config initialization (especially paths + colors) and config.json file creation
- Fix a crash when loading a build with less than 4 pools registered in the mxd file, increase backward compatibility for old builds (made with Mids 1.x)
- Fix for the bottom part of the main UI turning blank when loading a build, if it contains either accolades, incarnates or kheldian shapeshift powers
- RestSharp lib version updated to address potential security issue

DB:
- Fix critical hit related effects for Scrapper, standardize GCM flags being used.